### PR TITLE
Target V100 architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ The bulk of the code is written using NVIDIA's CUDA, and you will need a CUDA in
 The `include` directory contains the bulk of the code, which is written mostly as templated objects and functions. The `src` directory contains files for creating executables and libraries. The `bin` directory holds [compilation](#compiling) output. The `microlensing` directory contains [python](#python) code for ease of use, while the `examples` directory contains example python notebooks outlining usage.
 
 ## Compiling
-Compilation has been tested with the GNU compiler version 11.2.0 and the CUDA compiler version 12.4.
+Compilation has been tested with the GNU compiler version 11.2.0 and the CUDA compiler version 12.4. The provided `compile`
+script targets NVIDIA V100 GPUs (compute capability 7.0). If you wish to build for a different architecture, adjust the
+`-gencode` flags accordingly in that script.
 
 First, clone the repository.
 ```

--- a/compile
+++ b/compile
@@ -1,14 +1,14 @@
-nvcc -std=c++20 -gencode=arch=compute_80,code=\"sm_80,compute_80\" --use_fast_math -I ./include -O3 -D is_ipm -D is_float -o ./bin/ipm_gpu ./src/main_ipm_irs.cu
-nvcc -std=c++20 -gencode=arch=compute_80,code=\"sm_80,compute_80\" --use_fast_math -I ./include -O3 -D is_ipm -D is_double -o ./bin/ipm_gpu_double ./src/main_ipm_irs.cu
-nvcc -std=c++20 -gencode=arch=compute_80,code=\"sm_80,compute_80\" --use_fast_math -I ./include -O3 -D is_irs -D is_float -o ./bin/irs_gpu ./src/main_ipm_irs.cu
-nvcc -std=c++20 -gencode=arch=compute_80,code=\"sm_80,compute_80\" --compiler-options '-fPIC' --use_fast_math -I ./include -O3 -D is_float -shared -o ./bin/lib_ipm.so ./src/lib_ipm.cu 
-nvcc -std=c++20 -gencode=arch=compute_80,code=\"sm_80,compute_80\" --compiler-options '-fPIC' --use_fast_math -I ./include -O3 -D is_double -shared -o ./bin/lib_ipm_double.so ./src/lib_ipm.cu 
+nvcc -std=c++20 -gencode=arch=compute_70,code=\"sm_70,compute_70\" --use_fast_math -I ./include -O3 -D is_ipm -D is_float -o ./bin/ipm_gpu ./src/main_ipm_irs.cu
+nvcc -std=c++20 -gencode=arch=compute_70,code=\"sm_70,compute_70\" --use_fast_math -I ./include -O3 -D is_ipm -D is_double -o ./bin/ipm_gpu_double ./src/main_ipm_irs.cu
+nvcc -std=c++20 -gencode=arch=compute_70,code=\"sm_70,compute_70\" --use_fast_math -I ./include -O3 -D is_irs -D is_float -o ./bin/irs_gpu ./src/main_ipm_irs.cu
+nvcc -std=c++20 -gencode=arch=compute_70,code=\"sm_70,compute_70\" --compiler-options '-fPIC' --use_fast_math -I ./include -O3 -D is_float -shared -o ./bin/lib_ipm.so ./src/lib_ipm.cu
+nvcc -std=c++20 -gencode=arch=compute_70,code=\"sm_70,compute_70\" --compiler-options '-fPIC' --use_fast_math -I ./include -O3 -D is_double -shared -o ./bin/lib_ipm_double.so ./src/lib_ipm.cu
 
-nvcc -std=c++20 -gencode=arch=compute_80,code=\"sm_80,compute_80\" --use_fast_math -I ./include -O3 -D is_double -o ./bin/ccf_gpu ./src/main_ccf.cu
-nvcc -std=c++20 -gencode=arch=compute_80,code=\"sm_80,compute_80\" --compiler-options '-fPIC' --use_fast_math -I ./include -O3 -D is_double -shared -o ./bin/lib_ccf.so ./src/lib_ccf.cu 
+nvcc -std=c++20 -gencode=arch=compute_70,code=\"sm_70,compute_70\" --use_fast_math -I ./include -O3 -D is_double -o ./bin/ccf_gpu ./src/main_ccf.cu
+nvcc -std=c++20 -gencode=arch=compute_70,code=\"sm_70,compute_70\" --compiler-options '-fPIC' --use_fast_math -I ./include -O3 -D is_double -shared -o ./bin/lib_ccf.so ./src/lib_ccf.cu
 
-nvcc -std=c++20 -gencode=arch=compute_80,code=\"sm_80,compute_80\" --use_fast_math -I ./include -O3 -D is_double -o ./bin/ncc_gpu ./src/main_ncc.cu
-nvcc -std=c++20 -gencode=arch=compute_80,code=\"sm_80,compute_80\" --compiler-options '-fPIC' --use_fast_math -I ./include -O3 -D is_double -shared -o ./bin/lib_ncc.so ./src/lib_ncc.cu 
+nvcc -std=c++20 -gencode=arch=compute_70,code=\"sm_70,compute_70\" --use_fast_math -I ./include -O3 -D is_double -o ./bin/ncc_gpu ./src/main_ncc.cu
+nvcc -std=c++20 -gencode=arch=compute_70,code=\"sm_70,compute_70\" --compiler-options '-fPIC' --use_fast_math -I ./include -O3 -D is_double -shared -o ./bin/lib_ncc.so ./src/lib_ncc.cu
 
 mkdir -p ./microlensing/lib/
 cp ./bin/*.so ./microlensing/lib/


### PR DESCRIPTION
## Summary
- Update `compile` script to build for NVIDIA V100 (compute capability 7.0).
- Document V100 targeting in README and mention how to adjust gencode.

## Testing
- `source compile` *(fails: command not found: nvcc)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_688dbe685160832da888a08af7c3b5e6