### PR TITLE
Add CUDA-compatible numbers constants and build tweaks

### DIFF
--- a/compile
+++ b/compile
@@ -1,14 +1,14 @@
-nvcc -std=c++20 -gencode=arch=compute_70,code=\"sm_70,compute_70\" --use_fast_math -I ./include -O3 -D is_ipm -D is_float -o ./bin/ipm_gpu ./src/main_ipm_irs.cu
-nvcc -std=c++20 -gencode=arch=compute_70,code=\"sm_70,compute_70\" --use_fast_math -I ./include -O3 -D is_ipm -D is_double -o ./bin/ipm_gpu_double ./src/main_ipm_irs.cu
-nvcc -std=c++20 -gencode=arch=compute_70,code=\"sm_70,compute_70\" --use_fast_math -I ./include -O3 -D is_irs -D is_float -o ./bin/irs_gpu ./src/main_ipm_irs.cu
-nvcc -std=c++20 -gencode=arch=compute_70,code=\"sm_70,compute_70\" --compiler-options '-fPIC' --use_fast_math -I ./include -O3 -D is_float -shared -o ./bin/lib_ipm.so ./src/lib_ipm.cu
-nvcc -std=c++20 -gencode=arch=compute_70,code=\"sm_70,compute_70\" --compiler-options '-fPIC' --use_fast_math -I ./include -O3 -D is_double -shared -o ./bin/lib_ipm_double.so ./src/lib_ipm.cu
+nvcc -std=c++17 --expt-relaxed-constexpr -gencode=arch=compute_70,code=\"sm_70,compute_70\" --use_fast_math -I ./include -O3 -D is_ipm -D is_float -o ./bin/ipm_gpu ./src/main_ipm_irs.cu
+nvcc -std=c++17 --expt-relaxed-constexpr -gencode=arch=compute_70,code=\"sm_70,compute_70\" --use_fast_math -I ./include -O3 -D is_ipm -D is_double -o ./bin/ipm_gpu_double ./src/main_ipm_irs.cu
+nvcc -std=c++17 --expt-relaxed-constexpr -gencode=arch=compute_70,code=\"sm_70,compute_70\" --use_fast_math -I ./include -O3 -D is_irs -D is_float -o ./bin/irs_gpu ./src/main_ipm_irs.cu
+nvcc -std=c++17 --expt-relaxed-constexpr -gencode=arch=compute_70,code=\"sm_70,compute_70\" --compiler-options '-fPIC' --use_fast_math -I ./include -O3 -D is_float -shared -o ./bin/lib_ipm.so ./src/lib_ipm.cu
+nvcc -std=c++17 --expt-relaxed-constexpr -gencode=arch=compute_70,code=\"sm_70,compute_70\" --compiler-options '-fPIC' --use_fast_math -I ./include -O3 -D is_double -shared -o ./bin/lib_ipm_double.so ./src/lib_ipm.cu
 
-nvcc -std=c++20 -gencode=arch=compute_70,code=\"sm_70,compute_70\" --use_fast_math -I ./include -O3 -D is_double -o ./bin/ccf_gpu ./src/main_ccf.cu
-nvcc -std=c++20 -gencode=arch=compute_70,code=\"sm_70,compute_70\" --compiler-options '-fPIC' --use_fast_math -I ./include -O3 -D is_double -shared -o ./bin/lib_ccf.so ./src/lib_ccf.cu
+nvcc -std=c++17 --expt-relaxed-constexpr -gencode=arch=compute_70,code=\"sm_70,compute_70\" --use_fast_math -I ./include -O3 -D is_double -o ./bin/ccf_gpu ./src/main_ccf.cu
+nvcc -std=c++17 --expt-relaxed-constexpr -gencode=arch=compute_70,code=\"sm_70,compute_70\" --compiler-options '-fPIC' --use_fast_math -I ./include -O3 -D is_double -shared -o ./bin/lib_ccf.so ./src/lib_ccf.cu
 
-nvcc -std=c++20 -gencode=arch=compute_70,code=\"sm_70,compute_70\" --use_fast_math -I ./include -O3 -D is_double -o ./bin/ncc_gpu ./src/main_ncc.cu
-nvcc -std=c++20 -gencode=arch=compute_70,code=\"sm_70,compute_70\" --compiler-options '-fPIC' --use_fast_math -I ./include -O3 -D is_double -shared -o ./bin/lib_ncc.so ./src/lib_ncc.cu
+nvcc -std=c++17 --expt-relaxed-constexpr -gencode=arch=compute_70,code=\"sm_70,compute_70\" --use_fast_math -I ./include -O3 -D is_double -o ./bin/ncc_gpu ./src/main_ncc.cu
+nvcc -std=c++17 --expt-relaxed-constexpr -gencode=arch=compute_70,code=\"sm_70,compute_70\" --compiler-options '-fPIC' --use_fast_math -I ./include -O3 -D is_double -shared -o ./bin/lib_ncc.so ./src/lib_ncc.cu
 
 mkdir -p ./microlensing/lib/
 cp ./bin/*.so ./microlensing/lib/

--- a/include/alpha_smooth.cuh
+++ b/include/alpha_smooth.cuh
@@ -1,4 +1,5 @@
 #pragma once
+#include "compat_numbers.cuh"
 
 #include "complex.cuh"
 
@@ -88,7 +89,7 @@ __device__ Complex<T> alpha_smooth(Complex<T> z, T kappastar, int rectangular, C
 
 			a_smooth = (corner - z.conj()) * (corner.log() - s1) - (corner.conj() - z.conj()) * (corner.conj().log() - s2)
 				+ (-corner - z.conj()) * ((-corner).log() - s3) - (-corner.conj() - z.conj()) * ((-corner).conj().log() - s4);
-			a_smooth *= Complex<T>(0, -kappastar * std::numbers::inv_pi_v<T>);
+                    a_smooth *= Complex<T>(0, -kappastar * NSTD_INV_PI_V(T));
 			a_smooth -= kappastar * 2 * (corner.re + z.re);
 		}
 		else
@@ -99,7 +100,7 @@ __device__ Complex<T> alpha_smooth(Complex<T> z, T kappastar, int rectangular, C
 			Complex<T> c4 = -corner.conj() - z.conj();
 
 			a_smooth = c1 * c1.log() - c2 * c2.log() + c3 * c3.log() - c4 * c4.log();
-			a_smooth *= Complex<T>(0, -kappastar * std::numbers::inv_pi_v<T>);
+                    a_smooth *= Complex<T>(0, -kappastar * NSTD_INV_PI_V(T));
 			a_smooth -= kappastar * 2 * (corner.re + z.re) * boxcar(z, corner);
 			a_smooth -= kappastar * 4 * corner.re * heaviside(corner.im + z.im) * heaviside(corner.im - z.im) * heaviside(z.re - corner.re);
 		}
@@ -205,8 +206,8 @@ __device__ Complex<T> d_alpha_smooth_d_zbar(Complex<T> z, T kappastar, int recta
 			}
 			d_a_smooth_d_zbar *= 2;
 
-			d_a_smooth_d_zbar *= Complex<T>(0, -kappastar * std::numbers::inv_pi_v<T>);
-			d_a_smooth_d_zbar += kappastar - 4 * kappastar * corner.arg() * std::numbers::inv_pi_v<T>;
+                    d_a_smooth_d_zbar *= Complex<T>(0, -kappastar * NSTD_INV_PI_V(T));
+                    d_a_smooth_d_zbar += kappastar - 4 * kappastar * corner.arg() * NSTD_INV_PI_V(T);
 		}
 		else
 		{
@@ -216,7 +217,7 @@ __device__ Complex<T> d_alpha_smooth_d_zbar(Complex<T> z, T kappastar, int recta
 			Complex<T> c4 = -corner.conj() - z.conj();
 
 			d_a_smooth_d_zbar = c1.log() - c2.log() - c3.log() + c4.log();
-			d_a_smooth_d_zbar *= Complex<T>(0, -kappastar * std::numbers::inv_pi_v<T>);
+                    d_a_smooth_d_zbar *= Complex<T>(0, -kappastar * NSTD_INV_PI_V(T));
 			d_a_smooth_d_zbar -= kappastar * boxcar(z, corner);
 		}
 	}
@@ -272,7 +273,7 @@ __device__ Complex<T> d2_alpha_smooth_d_zbar2(Complex<T> z, T kappastar, int rec
 			d2_a_smooth_d_zbar2 /= z.conj();
 			d2_a_smooth_d_zbar2 *= 2;
 
-			d2_a_smooth_d_zbar2 *= Complex<T>(0, -kappastar * std::numbers::inv_pi_v<T>);
+                    d2_a_smooth_d_zbar2 *= Complex<T>(0, -kappastar * NSTD_INV_PI_V(T));
 		}
 		else
 		{
@@ -282,7 +283,7 @@ __device__ Complex<T> d2_alpha_smooth_d_zbar2(Complex<T> z, T kappastar, int rec
 			Complex<T> c4 = -corner.conj() - z.conj();
 
 			d2_a_smooth_d_zbar2 = -1 / c1 + 1 / c2 + 1 / c3 - 1 / c4;
-			d2_a_smooth_d_zbar2 *= Complex<T>(0, -kappastar * std::numbers::inv_pi_v<T>);
+                    d2_a_smooth_d_zbar2 *= Complex<T>(0, -kappastar * NSTD_INV_PI_V(T));
 		}
 	}
 	else

--- a/include/ccf.cuh
+++ b/include/ccf.cuh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "compat_numbers.cuh"
 #include "array_functions.cuh"
 #include "binomial_coefficients.cuh"
 #include "complex.cuh"
@@ -454,7 +455,7 @@ private:
 			if (rectangular)
 			{
 				corner = Complex<T>(std::sqrt(corner.re / corner.im), std::sqrt(corner.im / corner.re));
-				corner *= std::sqrt(std::numbers::pi_v<T> * theta_star * theta_star * num_stars * mean_mass / (4 * kappa_star));
+                    corner *= std::sqrt(NSTD_PI_V(T) * theta_star * theta_star * num_stars * mean_mass / (4 * kappa_star));
 				set_param("corner", corner, corner, verbose);
 			}
 			else
@@ -469,7 +470,7 @@ private:
 		set_param("alpha_error", alpha_error, theta_star * 0.0000001, verbose, !(rectangular && approx) && verbose < 3);
 
 		taylor_smooth = 1;
-		while ((kappa_star * std::numbers::inv_pi_v<T> * 4 / (taylor_smooth + 1) * corner.abs() * (safety_scale + 1) / (safety_scale - 1)
+            while ((kappa_star * NSTD_INV_PI_V(T) * 4 / (taylor_smooth + 1) * corner.abs() * (safety_scale + 1) / (safety_scale - 1)
 				* std::pow(1 / safety_scale, taylor_smooth + 1) > alpha_error)
 				&& taylor_smooth <= MAX_TAYLOR_SMOOTH)
 		{
@@ -480,8 +481,8 @@ private:
 		not in the correct fractional range of pi, increase taylor_smooth
 		this is due to NOT wanting cos(phase * (taylor_smooth - 1)) = 0, within errors
 		******************************************************************************/
-		while ((std::fmod(corner.arg() * (taylor_smooth - 1), std::numbers::pi_v<T>) < 0.1 * std::numbers::pi_v<T> 
-				|| std::fmod(corner.arg() * (taylor_smooth - 1), std::numbers::pi_v<T>) > 0.9 * std::numbers::pi_v<T>)
+            while ((std::fmod(corner.arg() * (taylor_smooth - 1), NSTD_PI_V(T)) < 0.1 * NSTD_PI_V(T)
+                            || std::fmod(corner.arg() * (taylor_smooth - 1), NSTD_PI_V(T)) > 0.9 * NSTD_PI_V(T))
 				&& taylor_smooth <= MAX_TAYLOR_SMOOTH)
 		{
 			taylor_smooth += 2;
@@ -710,7 +711,7 @@ private:
 			if (rectangular)
 			{
 				corner = Complex<T>(std::sqrt(corner.re / corner.im), std::sqrt(corner.im / corner.re));
-				corner *= std::sqrt(std::numbers::pi_v<T> * theta_star * theta_star * num_stars * mean_mass_actual / (4 * kappa_star));
+                    corner *= std::sqrt(NSTD_PI_V(T) * theta_star * theta_star * num_stars * mean_mass_actual / (4 * kappa_star));
 				set_param("corner", corner, corner, verbose, true);
 			}
 			else
@@ -742,8 +743,8 @@ private:
 			for (int i = 0; i < nroots_extra; i++)
 			{
 				ccs_init[center + 2 * num_stars + i] = corner.abs() *
-					Complex<T>(std::cos(2 * std::numbers::pi_v<T> / nroots_extra * i), 
-								std::sin(2 * std::numbers::pi_v<T> / nroots_extra * i));
+                                    Complex<T>(std::cos(2 * NSTD_PI_V(T) / nroots_extra * i),
+                                                   std::sin(2 * NSTD_PI_V(T) / nroots_extra * i));
 			}
 		}
 		print_verbose("Done initializing root positions.\n\n", verbose, 3);

--- a/include/ccf_functions.cuh
+++ b/include/ccf_functions.cuh
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
+#include "compat_numbers.cuh"
 #include "alpha_local.cuh"
 #include "alpha_smooth.cuh"
 #include "alpha_star.cuh"
@@ -335,13 +336,13 @@ __global__ void find_critical_curve_roots_kernel(T kappa, T gamma, T theta, star
 	T norm;
 	int sgn;
 
-	T dphi = 2 * std::numbers::pi_v<T> / nphi * j;
+    T dphi = 2 * NSTD_PI_V(T) / nphi * j;
 
 	for (int c = z_index; c < nbranches; c += z_stride)
 	{
 		for (int b = y_index; b < 2; b += y_stride)
 		{
-			T phi0 = std::numbers::pi_v<T> / nbranches + c * 2 * std::numbers::pi_v<T> / nbranches;
+                    T phi0 = NSTD_PI_V(T) / nbranches + c * 2 * NSTD_PI_V(T) / nbranches;
 
 			for (int a = x_index; a < nroots; a += x_stride)
 			{
@@ -431,13 +432,13 @@ __global__ void find_errors_kernel(Complex<T>* z, int nroots, T kappa, T gamma, 
 
 	int sgn;
 
-	T dphi = 2 * std::numbers::pi_v<T> / nphi * j;
+    T dphi = 2 * NSTD_PI_V(T) / nphi * j;
 
 	for (int c = z_index; c < nbranches; c += z_stride)
 	{
 		for (int b = y_index; b < 2; b += y_stride)
 		{
-			T phi0 = std::numbers::pi_v<T> / nbranches + c * 2 * std::numbers::pi_v<T> / nbranches;
+                    T phi0 = NSTD_PI_V(T) / nbranches + c * 2 * NSTD_PI_V(T) / nbranches;
 
 			for (int a = x_index; a < nroots; a += x_stride)
 			{

--- a/include/compat_numbers.cuh
+++ b/include/compat_numbers.cuh
@@ -1,0 +1,20 @@
+#pragma once
+#if defined(__CUDACC__)
+  #include <cuda/std/numbers>
+  namespace nst = cuda::std::numbers;
+#else
+  #include <numbers>
+  namespace nst = std::numbers;
+#endif
+// Fallback to avoid device-side variable-template issues
+template <typename T>
+__host__ __device__ constexpr T nst_pi_v() { return (T)3.14159265358979323846; }
+template <typename T>
+__host__ __device__ constexpr T nst_inv_pi_v() { return (T)0.31830988618379067154; } // 1/pi
+#if defined(__CUDACC__) || !defined(__cpp_lib_math_constants)
+  #define NSTD_PI_V(T)      nst_pi_v<T>()
+  #define NSTD_INV_PI_V(T)  nst_inv_pi_v<T>()
+#else
+  #define NSTD_PI_V(T)      nst::pi_v<T>
+  #define NSTD_INV_PI_V(T)  nst::inv_pi_v<T>
+#endif

--- a/include/ipm.cuh
+++ b/include/ipm.cuh
@@ -1,4 +1,5 @@
 #pragma once
+#include "compat_numbers.cuh"
 
 #include "array_functions.cuh"
 #include "binomial_coefficients.cuh"
@@ -519,12 +520,12 @@ private:
 				num_stars = std::ceil(
 					safety_scale * 2 * corner.re
 					* safety_scale * 2 * corner.im
-					* kappa_star / (std::numbers::pi_v<T> * theta_star * theta_star * mean_mass)
+                        * kappa_star / (NSTD_PI_V(T) * theta_star * theta_star * mean_mass)
 					);
 				set_param("num_stars", num_stars, num_stars, verbose);
 
 				corner = Complex<T>(std::sqrt(corner.re / corner.im), std::sqrt(corner.im / corner.re));
-				corner *= std::sqrt(std::numbers::pi_v<T> * theta_star * theta_star * num_stars * mean_mass / (4 * kappa_star));
+                    corner *= std::sqrt(NSTD_PI_V(T) * theta_star * theta_star * num_stars * mean_mass / (4 * kappa_star));
 				set_param("corner", corner, corner, verbose);
 			}
 			else
@@ -570,7 +571,7 @@ private:
 		set_param("alpha_error", alpha_error, alpha_error, verbose, !(rectangular && approx) && verbose < 3);
 
 		taylor_smooth = 1;
-		while ((kappa_star * std::numbers::inv_pi_v<T> * 4 / (taylor_smooth + 1) * corner.abs() * (safety_scale + 1) / (safety_scale - 1)
+            while ((kappa_star * NSTD_INV_PI_V(T) * 4 / (taylor_smooth + 1) * corner.abs() * (safety_scale + 1) / (safety_scale - 1)
 				* std::pow(1 / safety_scale, taylor_smooth + 1) > alpha_error)
 				&& taylor_smooth <= MAX_TAYLOR_SMOOTH)
 		{
@@ -581,8 +582,8 @@ private:
 		not in the correct fractional range of pi, increase taylor_smooth
 		this is due to NOT wanting cos(phase * (taylor_smooth - 1)) = 0, within errors
 		******************************************************************************/
-		while ((std::fmod(corner.arg() * (taylor_smooth - 1), std::numbers::pi_v<T>) < 0.1 * std::numbers::pi_v<T> 
-				|| std::fmod(corner.arg() * (taylor_smooth - 1), std::numbers::pi_v<T>) > 0.9 * std::numbers::pi_v<T>)
+            while ((std::fmod(corner.arg() * (taylor_smooth - 1), NSTD_PI_V(T)) < 0.1 * NSTD_PI_V(T)
+                            || std::fmod(corner.arg() * (taylor_smooth - 1), NSTD_PI_V(T)) > 0.9 * NSTD_PI_V(T))
 				&& taylor_smooth <= MAX_TAYLOR_SMOOTH)
 		{
 			taylor_smooth += 2;
@@ -749,7 +750,7 @@ private:
 			if (rectangular)
 			{
 				corner = Complex<T>(std::sqrt(corner.re / corner.im), std::sqrt(corner.im / corner.re));
-				corner *= std::sqrt(std::numbers::pi_v<T> * theta_star * theta_star * num_stars * mean_mass_actual / (4 * kappa_star));
+                    corner *= std::sqrt(NSTD_PI_V(T) * theta_star * theta_star * num_stars * mean_mass_actual / (4 * kappa_star));
 				set_param("corner", corner, corner, verbose, true);
 			}
 			else

--- a/include/irs.cuh
+++ b/include/irs.cuh
@@ -1,4 +1,5 @@
 #pragma once
+#include "compat_numbers.cuh"
 
 #include "array_functions.cuh"
 #include "binomial_coefficients.cuh"
@@ -502,12 +503,12 @@ private:
 				num_stars = std::ceil(
 					safety_scale * 2 * corner.re
 					* safety_scale * 2 * corner.im
-					* kappa_star / (std::numbers::pi_v<T> * theta_star * theta_star * mean_mass)
+                        * kappa_star / (NSTD_PI_V(T) * theta_star * theta_star * mean_mass)
 					);
 				set_param("num_stars", num_stars, num_stars, verbose);
 
 				corner = Complex<T>(std::sqrt(corner.re / corner.im), std::sqrt(corner.im / corner.re));
-				corner *= std::sqrt(std::numbers::pi_v<T> * theta_star * theta_star * num_stars * mean_mass / (4 * kappa_star));
+                    corner *= std::sqrt(NSTD_PI_V(T) * theta_star * theta_star * num_stars * mean_mass / (4 * kappa_star));
 				set_param("corner", corner, corner, verbose);
 			}
 			else
@@ -553,7 +554,7 @@ private:
 		set_param("alpha_error", alpha_error, alpha_error, verbose, !(rectangular && approx) && verbose < 3);
 
 		taylor_smooth = 1;
-		while ((kappa_star * std::numbers::inv_pi_v<T> * 4 / (taylor_smooth + 1) * corner.abs() * (safety_scale + 1) / (safety_scale - 1)
+            while ((kappa_star * NSTD_INV_PI_V(T) * 4 / (taylor_smooth + 1) * corner.abs() * (safety_scale + 1) / (safety_scale - 1)
 				* std::pow(1 / safety_scale, taylor_smooth + 1) > alpha_error)
 				&& taylor_smooth <= MAX_TAYLOR_SMOOTH)
 		{
@@ -564,8 +565,8 @@ private:
 		not in the correct fractional range of pi, increase taylor_smooth
 		this is due to NOT wanting cos(phase * (taylor_smooth - 1)) = 0, within errors
 		******************************************************************************/
-		while ((std::fmod(corner.arg() * (taylor_smooth - 1), std::numbers::pi_v<T>) < 0.1 * std::numbers::pi_v<T> 
-				|| std::fmod(corner.arg() * (taylor_smooth - 1), std::numbers::pi_v<T>) > 0.9 * std::numbers::pi_v<T>)
+            while ((std::fmod(corner.arg() * (taylor_smooth - 1), NSTD_PI_V(T)) < 0.1 * NSTD_PI_V(T)
+                            || std::fmod(corner.arg() * (taylor_smooth - 1), NSTD_PI_V(T)) > 0.9 * NSTD_PI_V(T))
 				&& taylor_smooth <= MAX_TAYLOR_SMOOTH)
 		{
 			taylor_smooth += 2;
@@ -732,7 +733,7 @@ private:
 			if (rectangular)
 			{
 				corner = Complex<T>(std::sqrt(corner.re / corner.im), std::sqrt(corner.im / corner.re));
-				corner *= std::sqrt(std::numbers::pi_v<T> * theta_star * theta_star * num_stars * mean_mass_actual / (4 * kappa_star));
+                            corner *= std::sqrt(NSTD_PI_V(T) * theta_star * theta_star * num_stars * mean_mass_actual / (4 * kappa_star));
 				set_param("corner", corner, corner, verbose, true);
 			}
 			else

--- a/include/star.cuh
+++ b/include/star.cuh
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
+#include "compat_numbers.cuh"
 #include "complex.cuh"
 #include "mass_functions.cuh"
 #include "util.cuh"
@@ -87,7 +88,7 @@ __global__ void generate_star_field_kernel(curandState* states, star<T>* stars, 
 			/******************************************************************************
 			random angle
 			******************************************************************************/
-			T a = curand_uniform_double(&states[i]) * 2 * std::numbers::pi_v<T>;
+                        T a = curand_uniform_double(&states[i]) * 2 * NSTD_PI_V(T);
 			/******************************************************************************
 			random radius uses square root of random number as numbers need to be evenly
 			dispersed in 2-D space
@@ -152,7 +153,7 @@ void calculate_star_params(int nstars, int rectangular, Complex<T> corner, T the
 
 	if (rectangular)
 	{
-		kappastar = m_tot * std::numbers::pi_v<T> * theta * theta / (4 * corner.re * corner.im);
+       kappastar = m_tot * NSTD_PI_V(T) * theta * theta / (4 * corner.re * corner.im);
 	}
 	else
 	{


### PR DESCRIPTION
## Summary
- add `compat_numbers.cuh` to provide math constants for host or CUDA builds
- include new header and replace `std::numbers` constants with `NSTD_PI_V` / `NSTD_INV_PI_V`
- build with C++17 and enable `--expt-relaxed-constexpr` in NVCC compile script

## Testing
- `nvcc --version` *(fails: command not found)*
- `bash compile` *(fails: nvcc: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f74126984832d9106cef460e2e02f